### PR TITLE
Fix export script, change directory search in export to wildcard match for model

### DIFF
--- a/Build-Image.ps1
+++ b/Build-Image.ps1
@@ -1,2 +1,0 @@
-# uupdump an image
-# apply customizations and scripts


### PR DESCRIPTION
Resolves #3

Fix errors on validating the import path (calling the wrong function name), clean up Initialize-ExportPath function, fix missing variables, add support for wildcard matching model names for export directory

Validate-ExportPath is trying to be called in the export driver script, but it should be Initialize-ExportPath.
https://github.com/hpst3r/WindowsInstallScripts/blob/main/Export-Drivers.ps1