### PR TITLE
Clean up scripts and properly comment. Add support for wildcard matching the machine name to Import script.

### DIFF
--- a/Export-Drivers.ps1
+++ b/Export-Drivers.ps1
@@ -1,21 +1,77 @@
 #Requires -RunAsAdministrator
-
-# Interactively export driver .inf files from a system in Audit Mode to a disk
+#Requires -Version 5.1
 
 function Export-Drivers {
+  <#
+  .SYNOPSIS
+  Interactively export driver .inf files from a system in Audit Mode to a disk
+  
+  .DESCRIPTION
+  This script exports drivers from the online Windows image to a .drivers\MODEL directory on a specified external disk.
+  If the directory does not exist, it will be created. If an exact or wildcard match for the model directory is found,
+  the user will be prompted to confirm overwriting it.
+  
+  .EXAMPLE
+  PS D:\scripts> .\Export-Drivers.ps1
+  Transcript started, output file is C:\Users\liam\AppData\Local\Temp\driver-export-OptiPlex 9020-1750886109
+  System model detected: 'OptiPlex 9020'.
+  Available volumes:
+
+  DriveLetter FileSystemLabel FileSystemType         Size SizeRemaining DriveType
+  ----------- --------------- --------------         ---- ------------- ---------
+                              FAT32             268435456     233230336 Fixed
+  C                           NTFS           999185969152  962233053184 Fixed
+  D           Ventoy          exFAT          127997050880  108174770176 Fixed
+  E           VTOYEFI         FAT                33277440       4793856 Fixed
+                              NTFS              726659072     120832000 Fixed
+
+
+  Please enter the drive letter for the target disk for driver export:
+  External drive letter (e.g., E:): D
+  Validating export path: 'D:\.drivers\OptiPlex 9020'...
+  No existing directory found. Creating one at: 'D:\.drivers\OptiPlex 9020'.
+  Creating model directory 'D:\.drivers\OptiPlex 9020'...
+  Path 'D:\.drivers\OptiPlex 9020' created successfully.
+  Exporting drivers from Windows image to D:\.drivers\OptiPlex 9020. This may take a while.
+
+  Driver           : oem0.inf
+  OriginalFileName : C:\Windows\System32\DriverStore\FileRepository\prnms009.inf_amd64_97613c6f44514bba\prnms009.inf
+  Inbox            : False
+  ClassName        : Printer
+  BootCritical     : False
+  ProviderName     : Microsoft
+  Date             : 6/21/2006 12:00:00 AM
+  Version          : 10.0.26100.1
+
+  ...snip...
+
+  Driver export completed. Drivers have been exported from the online image to 'D:\.drivers\OptiPlex 9020'.
+  Export process completed. Cleaning up...
+  Transcript stopped, output file is C:\Users\liam\AppData\Local\Temp\driver-export-OptiPlex 9020-1750886109
+  Moving transcript to the export directory...
+  Transcript moved to 'D:\.drivers\OptiPlex 9020\driver-export-OptiPlex 9020-1750886109'.
+  Cleanup complete.
+  #>
 
   function Select-ExportTargetDisk {
-    param (
-      [Parameter(Mandatory = $true)]
-      [string]$Model
-    )
+    <#
+    .SYNOPSIS
+    Select a target disk for driver export from available volumes.
+    .DESCRIPTION
+    This function lists all available volumes and prompts the user to select a drive letter,
+    then returns the selected drive letter with a colon appended if not already present.
+    .EXAMPLE
+    $ExternalDrive = Select-ExportTargetDisk
+    #>
+    [CmdletBinding()]
+    param ()
     
     $Volumes = (Get-Volume | Select-Object -Property DriveLetter, FileSystemLabel, FileSystemType, Size, SizeRemaining, DriveType)
 
     Write-Host @"
 Available volumes:
 $($Volumes | Format-Table -AutoSize | Out-String)
-Please enter the drive letter for the target disk for driver export:
+Please enter the drive letter of the disk you would like to export drivers to:
 "@
 
     $ExternalDrive = Read-Host "External drive letter (e.g., E:)"
@@ -29,8 +85,29 @@ Please enter the drive letter for the target disk for driver export:
 
   }
 
-  # validate the export path exists and create it if it does not
   function Initialize-ExportPath {
+    <#
+    .SYNOPSIS
+    Validate that the selected export path exists and create it if it does not.
+
+    .DESCRIPTION
+    This function validates the export path for driver export, ensuring that it exists or creating it if necessary.
+    If the directory already exists, it prompts the user for confirmation to overwrite it.
+
+    .PARAMETER ExternalDrive
+    The drive letter of the external drive where drivers will be exported. Provided by Select-ExportTargetDisk.
+
+    .PARAMETER Directory
+    The directory where drivers will be exported. In my case, this is ".drivers".
+
+    .PARAMETER Model
+    The model name of the machine, used to find and/or create a subdirectory to use for the driver export.
+
+    .EXAMPLE
+    $DriverPath = Initialize-ExportPath -ExternalDrive "D:" -Directory ".drivers" -Model "OptiPlex 9020"
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
     param (
       [Parameter(Mandatory = $true)]
       [string]$ExternalDrive,
@@ -122,7 +199,7 @@ Please enter the drive letter for the target disk for driver export:
 
     Write-Host "System model detected: '$($Model)'."
 
-    $ExternalDrive = (Select-ExportTargetDisk -Model $Model)
+    $ExternalDrive = (Select-ExportTargetDisk)
 
     $DriverPath = (Initialize-ExportPath -ExternalDrive $ExternalDrive -Directory ".drivers" -Model $Model)
 
@@ -138,7 +215,7 @@ Please enter the drive letter for the target disk for driver export:
     # export drivers from the online Windows image to the specified path
     Export-WindowsDriver -Online -Destination $DriverPath -ErrorAction Stop
 
-    Write-Host "Driver export completed. Drivers have been exported from the online image to '$($DriverPath)'."
+    Write-Host "Driver export completed. Drivers have been exported from the online image to '$($DriverPath)'." -ForegroundColor Green
   
   }
   finally {
@@ -156,9 +233,9 @@ Please enter the drive letter for the target disk for driver export:
 
       Write-Host "Moving transcript to the export directory..."
       Move-Item -Path $TranscriptPath -Destination $DriverPath
-      Write-Host "Transcript moved to '$($DriverPath)\$(($TranscriptPath -split '\\')[-1])'."
+      Write-Host "Transcript moved to '$($DriverPath)\$(($TranscriptPath -split '\\')[-1])'." -ForegroundColor Green
 
-      Write-Host "Cleanup complete."
+      Write-Host "Cleanup complete." -ForegroundColor Green
 
     }
     

--- a/Import-Drivers.ps1
+++ b/Import-Drivers.ps1
@@ -1,245 +1,263 @@
-# this script was originally authored by
-# seton at carmichaelcomputing.com, many thanks to him for the original code
+#Requires -RunAsAdministrator
+#Requires -Version 5.1
 
-<#
-.SYNOPSIS
-Search for driver files for a machine's model
-in a .drivers directory at the root of mounted drives.
+function Import-Drivers {
+  <#
+  .SYNOPSIS
+  Search for and install drivers for a machine's model
+  in a model-named .drivers directory at the root of all mounted drives.
 
-.INPUTS
-$Model:
-  the machine's Win32_ComputerSystem.Model identifier, e.g. '21G2002CUS'
-  or 'Dell Pro 16 PC16250' This is the directory that the function
-  will search for in the .drivers directory.
+  .DESCRIPTION
+  This script searches for a .drivers directory at the root of all filesystem drives,
+  then looks for a subdirectory named after the machine's model (e.g. '21G2002CUS' or
+  'Dell Pro 16 PC16250') within that directory (or a wildcard match, if an exact match is not found).
+  If found, it attempts to install any .inf files found in that directory with pnputil.
 
-.OUTPUTS
-$DriverFiles:
-  .inf children of located system model driver directory, if found
-  $false, if not found.
+  .EXAMPLE
+  PS C:\> Import-Drivers
 
-$DriverDirectoryRoot:
-  the PATH to .drivers at the root of a system drive, if found
-  $false, if not found.
+  .NOTES
+  This script was originally authored by seton at carmichaelcomputing.com,
+  many thanks to him for the original code.
+  #>
+  [CmdletBinding()]
+  param()
 
-.DESCRIPTION
-Searches for .drivers\MachineModel (e.g. .drivers\21G2002CUS) directory at the
-root of all system drives. This directory will have been previously populated
-with drivers by the Export-Drivers.ps1 script distributed in the same repository.
+  function Get-DriverFiles {
+    <#
+    .SYNOPSIS
+    Search for driver files for a machine's model
+    in a .drivers directory at the root of mounted drives.
 
-Returns objects pertaining to the driver files found in the model's directory,
-and the discovered .drivers directory itself (e.g. D:\.drivers or
-D:\.drivers\Dell Pro 16 PC16250, whichever is available).
+    .INPUTS
+    $Model:
+      the machine's Win32_ComputerSystem.Model identifier, e.g. '21G2002CUS'
+      or 'Dell Pro 16 PC16250' This is the directory that the function
+      will search for in the .drivers directory.
 
-The directory is used to move the execution log (transcript) to the removable disk.
+    .OUTPUTS
+    $DriverFiles:
+      .inf children of located system model driver directory, if found
+      $false, if not found.
 
-e.g.:
+    $DriverDirectoryRoot:
+      the PATH to .drivers at the root of a system drive, if found
+      $false, if not found.
 
-PS C:\WINDOWS\system32> $DriverFiles | Select FullName
+    .DESCRIPTION
+    Searches for .drivers\MachineModel (e.g. .drivers\21G2002CUS) directory at the
+    root of all system drives. This directory will have been previously populated
+    with drivers by the Export-Drivers.ps1 script distributed in the same repository.
 
-FullName
---------
-D:\.drivers\Dell Pro 16 PC16250\alderlakedmasecextension.inf_amd64_f0d7eea44ed4e421\AlderLakeDmaSecExtension.inf
-D:\.drivers\Dell Pro 16 PC16250\alderlakepch-ndmasecextension.inf_amd64_c1a7e34728e428a8\AlderLakePCH-NDmaSecExtensi...
-D:\.drivers\Dell Pro 16 PC16250\alderlakepch-nsystem.inf_amd64_23100d9890c77cd8\AlderLakePCH-NSystem.inf
-D:\.drivers\Dell Pro 16 PC16250\alderlakepch-nsystemnorthpeak.inf_amd64_5300f2fe1668d958\AlderLakePCH-NSystemNorthpe...
-D:\.drivers\Dell Pro 16 PC16250\alderlakepch-pdmasecextension.inf_amd64_c26ba4a8cd64b537\AlderLakePCH-PDmaSecExtensi...
-D:\.drivers\Dell Pro 16 PC16250\alderlakepch-psystem.inf_amd64_c27bc8858e991c72\AlderLakePCH-PSystem.inf
+    Returns objects pertaining to the driver files found in the model's directory,
+    and the discovered .drivers directory itself (e.g. D:\.drivers or
+    D:\.drivers\Dell Pro 16 PC16250, whichever is available).
 
-.EXAMPLE
-$DriverFiles, $DriverDirectory = Get-DriverFiles -Model 'Dell Pro 16 PC16250'
-#>
-function Get-DriverFiles {
-  param (
-    [Parameter(Mandatory = $true)]
-    [string]$Model
-  )
-  
-  # Search for .drivers directory at the root of all filesystem PS drives
-  $DriverDirectoryRoot = (
-    Get-PSDrive -PSProvider FileSystem | ForEach-Object {
+    The directory is used to move the execution log (transcript) to the removable disk.
 
-      $RootPath = "$($_.Root).drivers"
+    e.g.:
 
-      if (Test-Path $RootPath) {
-        $RootPath
+    PS C:\WINDOWS\system32> $DriverFiles | Select FullName
+
+    FullName
+    --------
+    D:\.drivers\Dell Pro 16 PC16250\alderlakedmasecextension.inf_amd64_f0d7eea44ed4e421\AlderLakeDmaSecExtension.inf
+    D:\.drivers\Dell Pro 16 PC16250\alderlakepch-ndmasecextension.inf_amd64_c1a7e34728e428a8\AlderLakePCH-NDmaSecExtensi...
+    D:\.drivers\Dell Pro 16 PC16250\alderlakepch-nsystem.inf_amd64_23100d9890c77cd8\AlderLakePCH-NSystem.inf
+    D:\.drivers\Dell Pro 16 PC16250\alderlakepch-nsystemnorthpeak.inf_amd64_5300f2fe1668d958\AlderLakePCH-NSystemNorthpe...
+    D:\.drivers\Dell Pro 16 PC16250\alderlakepch-pdmasecextension.inf_amd64_c26ba4a8cd64b537\AlderLakePCH-PDmaSecExtensi...
+    D:\.drivers\Dell Pro 16 PC16250\alderlakepch-psystem.inf_amd64_c27bc8858e991c72\AlderLakePCH-PSystem.inf
+
+    .EXAMPLE
+    $DriverFiles, $DriverDirectory = Get-DriverFiles -Model 'Dell Pro 16 PC16250'
+    #>
+    param (
+      [Parameter(Mandatory = $true)]
+      [string]$Model
+    )
+    
+    # Search for a .drivers directory at the root of all filesystem drives
+    $DriverDirectoryRoot = Get-PSDrive -PSProvider FileSystem |
+      Where-Object { Test-Path "$($_.Root).drivers" } |
+      Select-Object -ExpandProperty Root -First 1
+    
+    if ($DriverDirectoryRoot) {
+
+      $DriverDirectoryRoot = "$DriverDirectoryRoot.drivers"
+
+      Write-Host "Found .drivers directory: '$($DriverDirectoryRoot)'" -ForegroundColor Green
+      
+      $Directories = Get-ChildItem -Path $DriverDirectoryRoot -Directory
+
+      # Try exact match (case-insensitive)
+      $DriverDirectory = $Directories | Where-Object { $_.Name -ieq $Model } | Select-Object -First 1
+
+      # If not found, try wildcard match (case-insensitive)
+      if (-not $DriverDirectory) {
+          Write-Host "No exact match for model '$($Model)' found in $($DriverDirectoryRoot). Looking for a wildcard match." -ForegroundColor Yellow
+          $DriverDirectory = $Directories | Where-Object { $_.Name -ilike "*$($Model)*" } | Select-Object -First 1
       }
 
-    } | Select-Object -First 1
-  )
+      if ($DriverDirectory) {
 
-  if ($DriverDirectoryRoot) {
+        Write-Host "Found driver directory for model '$($Model)': $($DriverDirectory.FullName)" -ForegroundColor Green
 
-    Write-Host "Found .drivers directory at: $DriverDirectoryRoot"
-    
-    # Look for a Directory matching the exact model number (case-insensitive)
-    $DriverDirectory = (
-      Get-ChildItem -Path $DriverDirectoryRoot | 
-        Where-Object {
-          $_.PSIsContainer -and (
-            $_.Name -like "$($Model)*" -or
-            $_.Name -eq $Model
-          )
-        } | 
-        Select-Object -First 1
-    )
+        # Get all .inf files in the driver directory and its subdirectories
+        $DriverFiles = Get-ChildItem -Path $DriverDirectory.FullName -Recurse -Include "*.inf"
 
-    if ($DriverDirectory) {
+        if ($DriverFiles) {
+          
+          return $DriverFiles, $DriverDirectory
 
-      Write-Host "Found driver directory for model '$($Model)': $($DriverDirectory.FullName)"
+        } else {
 
-      $DriverFiles = Get-ChildItem -Path $DriverDirectory.FullName -Recurse -Include "*.inf"
+          Write-Error "No driver files (.inf) found in $($DriverDirectory.FullName). Execution cannot continue."
+          return $false, $DriverDirectory
 
-      if ($DriverFiles) {
-        
-        return $DriverFiles, $DriverDirectory
+        }
 
       } else {
 
-        Write-Error "No driver files (.inf) found in $($DriverDirectory.FullName). Execution cannot continue."
-
-        return $false, $DriverDirectory
+        Write-Error "No directory for device model '$($Model)' found at $($DriverDirectoryRoot). Looking for a wildcard match."
+        return $false, $DriverDirectoryRoot
 
       }
 
     } else {
 
-      Write-Error "No directory for device model '$($Model)' found at $($DriverDirectoryRoot). Execution cannot continue."
-      
-      return $false, $DriverDirectoryRoot
+      Write-Error "No '.drivers' directory found at the root of drives on this system. Execution cannot continue."
+      return $false, $false
 
     }
 
-  } else {
-
-    Write-Error "No '.drivers' directory found at the root of drives on this system. Execution cannot continue."
-
-    return $false, $false
-
   }
 
-}
+  function Install-Drivers {
+    <#
+    .SYNOPSIS
+    Install an array of .infs with pnputil.
 
-<#
-.SYNOPSIS
-Install an array of .infs with pnputil.
+    .INPUTS
+    Object[] $DriverFiles:
+      Output from Get-Drivers or Get-ChildItem -Recurse -Include "*.inf" -
+      an array of System.IO.FileSystemInfo objects pointing to driver .inf
+      files to be installed.
 
-.INPUTS
-Object[] $DriverFiles:
-  Output from Get-Drivers or Get-ChildItem -Recurse -Include "*.inf" -
-  an array of System.IO.FileSystemInfo objects pointing to driver .inf
-  files to be installed.
+    .OUTPUTS
+    $SuccessCount:
+      The total number of drivers successfully installed with pnputil.
 
-.OUTPUTS
-$SuccessCount:
-  The total number of drivers successfully installed with pnputil.
+    $FailureCount:
+      The total number of drivers that pnputil failed to install.
 
-$FailureCount:
-  The total number of drivers that pnputil failed to install.
+    .DESCRIPTION
+    Simple wrapper to install .inf files passed via an array of FileInfo objects
+    produced by G-CItem by calling pnputil. Counts success and failures.
+    #>
+    param (
+      [Parameter(Mandatory = $true)]
+      [Object[]]$DriverFiles
+    )
+          
+    $TotalDrivers = $DriverFiles.Count
+    $CurrentDriver, $SuccessCount, $FailureCount = 0, 0, 0
 
-.DESCRIPTION
-Simple wrapper to install .inf files passed via an array of FileInfo objects
-produced by G-CItem by calling pnputil. Counts success and failures.
-#>
-function Install-Drivers {
-  param (
-    [Parameter(Mandatory = $true)]
-    [Object[]]$DriverFiles
-  )
+    foreach ($DriverFile in $DriverFiles) {
+
+      $CurrentDriver++
+
+      try {
+          
+        Write-Host "($($CurrentDriver)/$($TotalDrivers)) Installing driver: $($DriverFile.FullName)"
         
-  $TotalDrivers = $DriverFiles.Count
-  $CurrentDriver, $SuccessCount, $FailureCount = 0, 0, 0
-
-  foreach ($DriverFile in $DriverFiles) {
-
-    $CurrentDriver++
-
-    try {
+        # cannot use Add-WindowsDriver here as it does not support online installation
+        $Result = & pnputil.exe /add-driver "$($DriverFile.FullName)" /install
         
-      Write-Host "($CurrentDriver/$TotalDrivers) Installing driver: $($DriverFile.FullName)"
-      
-      # cannot use Add-WindowsDriver here as it does not support online installation
-      $Result = & pnputil.exe /add-driver "$($DriverFile.FullName)" /install
-      
-      if ($Result -match "Failed") {
+        if ($Result -match "Failed") {
+            $FailureCount++
+            Write-Host "Failed to install driver: $($DriverFile.Name)"
+        } else {
+            $SuccessCount++
+            Write-Host "Successfully installed driver: $($DriverFile.Name)"
+        }
 
-          $FailureCount++
-          Write-Host "Failed to install driver: $($DriverFile.Name)"
+      } catch {
 
-      } else {
-
-          $SuccessCount++
-          Write-Host "Successfully installed driver: $($DriverFile.Name)"
+        $FailureCount++
+        Write-Host "Error installing driver: $($_.Exception.Message)"
 
       }
 
-    } catch {
-
-      $FailureCount++
-      Write-Host "Error installing driver: $($_.Exception.Message)"
-
     }
+
+    return $SuccessCount, $FailureCount
 
   }
 
-  return $SuccessCount, $FailureCount
+  try {
 
-}
+    # get the system model, manufacturer, and serial number
+    # model will be used to search for the driver directory
+    # mfg, s/n will be used to label execution log
 
-# get the system model, manufacturer, and serial number
-# model will be used to search for the driver directory
-# mfg, s/n will be used to label execution log
-$Model = (Get-CimInstance -Class Win32_ComputerSystem).Model
-$Manufacturer = (Get-CimInstance -Class Win32_ComputerSystem).Manufacturer
-$SerialNumber = (Get-CimInstance -Class Win32_BIOS).SerialNumber
+    $Model = (Get-CimInstance -Class Win32_ComputerSystem).Model
+    $Manufacturer = (Get-CimInstance -Class Win32_ComputerSystem).Manufacturer
+    $SerialNumber = (Get-CimInstance -Class Win32_BIOS).SerialNumber
 
-# create an identifiable transcript
-$TranscriptPath = "$($env:TEMP)\driver-import-$($Manufacturer)-$($Model)-$($SerialNumber)-$(Get-Date -UFormat %s).log"
+    # create an identifiable transcript
+    $TranscriptPath = "$($env:TEMP)\driver-import-$($Manufacturer)-$($Model)-$($SerialNumber)-$(Get-Date -UFormat %s).log"
 
-Start-Transcript -Path $TranscriptPath
+    Start-Transcript -Path $TranscriptPath
 
-$DriverFiles, $DriverDirectory = Get-DriverFiles -Model $Model
+    $DriverFiles, $DriverDirectory = Get-DriverFiles -Model $Model
 
-if ($DriverFiles) {
+    if ($DriverFiles) {
 
-  Write-Host "Starting driver installation from directory: $($DriverDirectory.FullName) at $(Get-Date -UFormat %s)"
+      Write-Host "Starting driver installation from directory: $($DriverDirectory.FullName) at $(Get-Date -UFormat %s)"
 
-  $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+      $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-  $SuccessCount, $FailureCount = Install-Drivers -DriverFiles $DriverFiles
+      $SuccessCount, $FailureCount = Install-Drivers -DriverFiles $DriverFiles
 
-  $Stopwatch.Stop()
+      $Stopwatch.Stop()
 
-  # this is in Install-Drivers, but it's probably clearer to redefine it here than receive it, too.
-  $TotalDrivers = $DriverFiles.Count
+      # this is in Install-Drivers, but it's probably clearer to redefine it here than receive it, too.
+      $TotalDrivers = $DriverFiles.Count
 
-  # log details about 'transaction' (god I wish I had dnf) to console and transcript.
-  Write-Host @"
+      # log details about 'transaction' (god I wish I had dnf) to console and transcript.
+      Write-Host @"
 Driver import from $($DriverDirectory.FullName) completed at $(Get-Date -UFormat %s)
 Duration: $($Stopwatch.Elapsed.TotalSeconds) seconds
 Processed $($TotalDrivers) driver(s)
-Successfully installed: $SuccessCount
-Failed to install: $FailureCount
+Successfully installed: $($SuccessCount)
+Failed to install: $($FailureCount)
 "@
 
-} else {
+    } else {
 
-  Write-Error "Drivers for system model '$($Model)' were not found and thus cannot be installed. No changes were made."
+      Write-Error "Drivers for system model '$($Model)' were not found and thus cannot be installed. No changes were made."
+      $DriverDirectory = $false # this is just for the final move-item to work correctly
 
-  $DriverDirectory = $false
+    }
+
+  } finally {
+
+    Stop-Transcript
+
+    # if the $DriverDirectory was found by Get-DriverFiles, move the transcript there
+    # this will drop the transcript in either drive:\.drivers\model or drive:\.drivers
+    # if model's directory is or is not found, respectively.
+    if ($DriverDirectory) {
+
+      Write-Host "Moving transcript to driver directory at: $($DriverDirectory.FullName)."
+      Move-Item -Path $TranscriptPath -Destination $DriverDirectory.FullName
+
+    }
+
+    Write-Host "Execution completed at $(Get-Date -UFormat %s)."
+
+  }
 
 }
 
-Stop-Transcript
-
-# if the $DriverDirectory was found by Get-DriverFiles, move the transcript there
-# this will drop the transcript in either drive:\.drivers\model or drive:\.drivers
-# if model's directory is or is not found.
-if ($DriverDirectory) {
-
-  Write-Host "Moving transcript to driver directory at: $($DriverDirectory.FullName)."
-
-  Move-Item -Path $TranscriptPath -Destination $DriverDirectory.FullName
-
-}
-
-Write-Host "Execution completed at $(Get-Date -UFormat %s)."
+Import-Drivers

--- a/Update-VentoyDrive.ps1
+++ b/Update-VentoyDrive.ps1
@@ -1,0 +1,3 @@
+# Search for a directory named .scripts at the root of all filesystem PS drives
+# replace any scripts in the directory with the same name as a script in this repository
+# (rename superseded versions to OLD-<name>_<date>.ps1)


### PR DESCRIPTION
Resolves #5, resolves #7, resolves #8

Clean up both the Import- and Export-Drivers scripts a bit. Add comment-based help for all functions.

Move existing comment-based help into functions themselves, per best practice. Add Requires blocks.

Tested on OptiPlex 9020, Dell 7320 Detachable, Lenovo P14s Gen 5i running Windows 11, version 24H2.